### PR TITLE
Explicit licensing

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+
+The MIT License (MIT)
+Copyright © 2015 Jeff Emminger <jeff@7compass.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ scores and tokens, e.g.:
 
     gem install sentimental
 
+## License
+
+MIT License
+
 ## Credits
 
 Based largely on Christopher MacLellan's script:

--- a/lib/sentimental.rb
+++ b/lib/sentimental.rb
@@ -1,7 +1,6 @@
 
 # Based on code from https://github.com/cmaclell/Basic-Tweet-Sentiment-Analyzer
 
-
 #############################################################################
 # Copyright: Christopher MacLellan 2010
 # Description: This code adds functions to the string class for calculating
@@ -61,7 +60,7 @@ class Sentimental
   def get_score(string)
     sentiment_total = 0.0
 
-    #tokenize the string, also throw away some punctuation
+    # tokenize the string, also throw away some punctuation
     tokens = string.to_s.downcase.split(/\W*\s+\W*|^\W+|\W+$/)
 
     tokens.each do |token|
@@ -112,5 +111,4 @@ class Sentimental
   def self.threshold=(threshold)
     @@threshold = threshold
   end
-
 end

--- a/sentimental.gemspec
+++ b/sentimental.gemspec
@@ -1,15 +1,15 @@
 Gem::Specification.new do |s|
-  s.name         = "sentimental"
-  s.version      = "1.0.4"
+  s.name         = 'sentimental'
+  s.version      = '1.0.4'
   s.date         = Date.today
-  s.summary      = "Simple sentiment analysis"
-  s.description  = "A simple sentiment analysis gem"
-  s.authors      = ["Jeff Emminger", "Christopher MacLellan"]
-  s.email        = "jeff@7compass.com"
-  s.license      = "MIT"
-  s.files        = Dir["lib/*"] << "README.md"
-  s.homepage     = "https://github.com/7compass/sentimental"
+  s.summary      = 'Simple sentiment analysis'
+  s.description  = 'A simple sentiment analysis gem'
+  s.authors      = ['Jeff Emminger', 'Christopher MacLellan']
+  s.email        = 'jeff@7compass.com'
+  s.license      = 'MIT'
+  s.files        = Dir['lib/*'] << 'README.md'
+  s.homepage     = 'https://github.com/7compass/sentimental'
   s.platform     = Gem::Platform::RUBY
-  s.require_path = "."
-  s.require_paths << "lib"
+  s.require_path = '.'
+  s.require_paths << 'lib'
 end

--- a/sentimental.gemspec
+++ b/sentimental.gemspec
@@ -6,10 +6,10 @@ Gem::Specification.new do |s|
   s.description  = "A simple sentiment analysis gem"
   s.authors      = ["Jeff Emminger", "Christopher MacLellan"]
   s.email        = "jeff@7compass.com"
+  s.license      = "MIT"
   s.files        = Dir["lib/*"] << "README.md"
   s.homepage     = "https://github.com/7compass/sentimental"
   s.platform     = Gem::Platform::RUBY
   s.require_path = "."
   s.require_paths << "lib"
-  s.license      = "MIT"
 end


### PR DESCRIPTION
`sentimental.gemspec` indicated the code was MIT-licensed, but there was no license included in the repository or the readme. This PR adds those, along with some minor stylistic changes (in separate commits, if you'd prefer to cherry-pick around them).