### PR TITLE
Remove explicit dependency on gems in stdlib

### DIFF
--- a/sentimental.gemspec
+++ b/sentimental.gemspec
@@ -17,6 +17,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0.0"
   spec.add_development_dependency "rubocop", "~> 0.40", ">= 0.40.0"
-
-  spec.add_runtime_dependency "json", "~> 1.8", ">= 1.8.3"
 end


### PR DESCRIPTION
`json` is included in the Ruby standard library for all supported versions of Ruby.